### PR TITLE
Simplify CI workflow for public repo

### DIFF
--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -14,24 +14,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v2
-        id: app-token
-        with:
-          app-id: ${{ secrets.AUTH_APP_ID }}
-          private-key: ${{ secrets.AUTH_APP_SECRET_KEY }}
-          owner: ${{ github.repository_owner }}
       - uses: actions/checkout@v5
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
-          ref: ${{ github.event.inputs.branch }}
-          submodules: recursive
-          lfs: true
-          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v4
       - run: uv python install 3.12
-      - run: git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
       - run: uv sync --extra dev
       - run: uv run ruff format --check src tests
       - run: uv run ruff check src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,6 @@ url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Night
 explicit = true
 
 [tool.uv.sources]
-transformers = { git = "ssh://git@github.com/Liquid4All/transformers_private.git", branch = "lfm2-config" }
+transformers = { git = "https://github.com/huggingface/transformers.git", rev = "3c25177" }
 onnxruntime = { index = "ort-nightly" }
 onnxruntime-gpu = { index = "ort-nightly" }


### PR DESCRIPTION
## Summary
- Remove GitHub App token creation for private repo access
- Simplify checkout step (no token, submodules, LFS, or custom ref)
- Remove git URL rewrite for SSH→HTTPS with token

This makes the CI workflow suitable for a public repo without private dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)