### PR TITLE
Add Transformers.js v4 compatibility

### DIFF
--- a/src/liquidonnx/lfm2_vl/export.py
+++ b/src/liquidonnx/lfm2_vl/export.py
@@ -11,14 +11,14 @@ Output Structure (Transformers.js compatible):
         └── onnx/
             ├── embed_tokens.onnx          # FP32
             ├── embed_tokens_fp16.onnx     # --precision fp16
-            ├── embed_images.onnx          # FP32
-            ├── embed_images_fp16.onnx     # --precision fp16
-            ├── embed_images_q4.onnx       # --precision q4
-            ├── embed_images_q8.onnx       # --precision q8
-            ├── decoder.onnx               # FP32
-            ├── decoder_fp16.onnx          # --precision fp16
-            ├── decoder_q4.onnx            # --precision q4
-            └── decoder_q8.onnx            # --precision q8
+            ├── vision_encoder.onnx          # FP32
+            ├── vision_encoder_fp16.onnx     # --precision fp16
+            ├── vision_encoder_q4.onnx       # --precision q4
+            ├── vision_encoder_q8.onnx       # --precision q8
+            ├── decoder_model_merged.onnx               # FP32
+            ├── decoder_model_merged_fp16.onnx          # --precision fp16
+            ├── decoder_model_merged_q4.onnx            # --precision q4
+            └── decoder_model_merged_q8.onnx            # --precision q8
 
 Usage:
     # Export from HuggingFace
@@ -46,6 +46,7 @@ import gc
 import json
 import logging
 import pathlib
+import re
 
 import onnx
 from onnx import TensorProto, helper
@@ -157,7 +158,7 @@ def export_vl_model(
     output_dir: pathlib.Path | str,
     vision_input_format: str = VISION_MODE_TILED,
 ):
-    """Export LFM2-VL model to ONNX (embed_tokens + embed_images + decoder).
+    """Export LFM2-VL model to ONNX (embed_tokens + vision_encoder + decoder).
 
     Args:
         model_path: HuggingFace model path
@@ -215,8 +216,8 @@ def export_vl_model(
     vision_builder.load_weights(weights)
     vision_model = vision_builder.build()
 
-    vision_path = onnx_dir / "embed_images.onnx"
-    vision_data_path = onnx_dir / "embed_images.onnx_data"
+    vision_path = onnx_dir / "vision_encoder.onnx"
+    vision_data_path = onnx_dir / "vision_encoder.onnx_data"
     if vision_data_path.exists():
         vision_data_path.unlink()
     onnx.save_model(
@@ -224,7 +225,7 @@ def export_vl_model(
         str(vision_path),
         save_as_external_data=True,
         all_tensors_to_one_file=True,
-        location="embed_images.onnx_data",
+        location="vision_encoder.onnx_data",
         size_threshold=1024,
     )
     logger.info(f"embed_images saved to {vision_path}")
@@ -357,8 +358,8 @@ def export_vl_model(
     text_builder.initializers.clear()
     gc.collect()
 
-    decoder_path = onnx_dir / "decoder.onnx"
-    decoder_data_path = onnx_dir / "decoder.onnx_data"
+    decoder_path = onnx_dir / "decoder_model_merged.onnx"
+    decoder_data_path = onnx_dir / "decoder_model_merged.onnx_data"
     if decoder_data_path.exists():
         decoder_data_path.unlink()
 
@@ -368,7 +369,7 @@ def export_vl_model(
         str(decoder_path),
         save_as_external_data=True,
         all_tensors_to_one_file=True,
-        location="decoder.onnx_data",
+        location="decoder_model_merged.onnx_data",
         size_threshold=1024,
     )
     logger.info(f"decoder saved to {decoder_path}")
@@ -386,6 +387,42 @@ def export_vl_model(
         tokenizer.save_pretrained(output_dir)
 
     config.save_pretrained(output_dir)
+
+    # === 1. Create preprocessor_config.json (flat format for Transformers.js) ===
+    processor_config_path = output_dir / "processor_config.json"
+    if processor_config_path.exists():
+        processor_config = json.loads(processor_config_path.read_text())
+        image_processor = processor_config.get("image_processor", {})
+        preprocessor_config = {
+            **image_processor,
+            "processor_class": processor_config.get("processor_class", "Lfm2VlProcessor"),
+        }
+        preprocessor_path = output_dir / "preprocessor_config.json"
+        preprocessor_path.write_text(json.dumps(preprocessor_config, indent=2))
+
+    # === 2. Inline chat_template into tokenizer_config.json ===
+    chat_template_path = output_dir / "chat_template.jinja"
+    tokenizer_config_path = output_dir / "tokenizer_config.json"
+    if chat_template_path.exists() and tokenizer_config_path.exists():
+        tokenizer_config = json.loads(tokenizer_config_path.read_text())
+        if "chat_template" not in tokenizer_config:
+            template = chat_template_path.read_text()
+            template = re.sub(r"\{%-?\s*generation\s*-?%\}", "", template)
+            template = re.sub(r"\{%-?\s*endgeneration\s*-?%\}", "", template)
+            tokenizer_config["chat_template"] = template
+            tokenizer_config_path.write_text(json.dumps(tokenizer_config, indent=2))
+
+    # === 3. Add transformers.js_config to config.json ===
+    config_path = output_dir / "config.json"
+    config_dict = json.loads(config_path.read_text())
+    config_dict["transformers.js_config"] = {
+        "use_external_data_format": {
+            "vision_encoder": True,
+            "embed_tokens": True,
+            "decoder_model_merged": True,
+        },
+    }
+    config_path.write_text(json.dumps(config_dict, indent=2))
 
     # Create generation_config.json
     gen_config = {
@@ -455,10 +492,10 @@ def do_quantize(
         f"vision=q{vision_bits} ({quant_type})..."
     )
 
-    # Quantize embed_images
-    embed_fp32 = onnx_dir / "embed_images.onnx"
+    # Quantize vision_encoder
+    embed_fp32 = onnx_dir / "vision_encoder.onnx"
 
-    embed_output = onnx_dir / f"embed_images_q{vision_bits}.onnx"
+    embed_output = onnx_dir / f"vision_encoder_q{vision_bits}.onnx"
     if embed_fp32.exists() and not embed_output.exists():
         _, embed_orig_mb = get_model_size(embed_fp32)
         quantize_model(
@@ -471,14 +508,14 @@ def do_quantize(
         )
         _, embed_quant_mb = get_model_size(embed_output)
         logger.info(
-            f"  embed_images: {embed_orig_mb:.1f} -> {embed_quant_mb:.1f} MB "
+            f"  vision_encoder: {embed_orig_mb:.1f} -> {embed_quant_mb:.1f} MB "
             f"({embed_orig_mb / embed_quant_mb:.1f}x)"
         )
 
-    # Quantize decoder
-    decoder_fp32 = onnx_dir / "decoder.onnx"
+    # Quantize decoder_model_merged
+    decoder_fp32 = onnx_dir / "decoder_model_merged.onnx"
 
-    decoder_output = onnx_dir / f"decoder_q{decoder_bits}.onnx"
+    decoder_output = onnx_dir / f"decoder_model_merged_q{decoder_bits}.onnx"
     if decoder_fp32.exists() and not decoder_output.exists():
         _, decoder_orig_mb = get_model_size(decoder_fp32)
         quantize_model(
@@ -491,7 +528,7 @@ def do_quantize(
         )
         _, decoder_quant_mb = get_model_size(decoder_output)
         logger.info(
-            f"  decoder: {decoder_orig_mb:.1f} -> {decoder_quant_mb:.1f} MB "
+            f"  decoder_model_merged: {decoder_orig_mb:.1f} -> {decoder_quant_mb:.1f} MB "
             f"({decoder_orig_mb / decoder_quant_mb:.1f}x)"
         )
 
@@ -501,8 +538,8 @@ def do_fp16(onnx_dir: pathlib.Path):
 
     Creates:
     - embed_tokens_fp16.onnx
-    - embed_images_fp16.onnx
-    - decoder_fp16.onnx
+    - vision_encoder_fp16.onnx
+    - decoder_model_merged_fp16.onnx
     """
     if not onnx_dir.exists():
         raise FileNotFoundError(f"ONNX directory not found: {onnx_dir}")
@@ -515,15 +552,15 @@ def do_fp16(onnx_dir: pathlib.Path):
     if embed_tokens_fp32.exists() and not embed_tokens_fp16.exists():
         convert_to_fp16(embed_tokens_fp32, embed_tokens_fp16)
 
-    # Convert embed_images
-    embed_images_fp32 = onnx_dir / "embed_images.onnx"
-    embed_images_fp16 = onnx_dir / "embed_images_fp16.onnx"
-    if embed_images_fp32.exists() and not embed_images_fp16.exists():
-        convert_to_fp16(embed_images_fp32, embed_images_fp16)
+    # Convert vision_encoder
+    vision_encoder_fp32 = onnx_dir / "vision_encoder.onnx"
+    vision_encoder_fp16 = onnx_dir / "vision_encoder_fp16.onnx"
+    if vision_encoder_fp32.exists() and not vision_encoder_fp16.exists():
+        convert_to_fp16(vision_encoder_fp32, vision_encoder_fp16)
 
-    # Convert decoder
-    decoder_fp32 = onnx_dir / "decoder.onnx"
-    decoder_fp16 = onnx_dir / "decoder_fp16.onnx"
+    # Convert decoder_model_merged
+    decoder_fp32 = onnx_dir / "decoder_model_merged.onnx"
+    decoder_fp16 = onnx_dir / "decoder_model_merged_fp16.onnx"
     if decoder_fp32.exists() and not decoder_fp16.exists():
         convert_to_fp16(decoder_fp32, decoder_fp16)
 

--- a/src/liquidonnx/lfm2_vl/infer.py
+++ b/src/liquidonnx/lfm2_vl/infer.py
@@ -14,8 +14,8 @@ Usage:
     # Specify individual component files
     uv run lfm2-vl-infer --model exports/LFM2-VL-450M-ONNX \
         --embed-tokens embed_tokens_fp16.onnx \
-        --embed-images embed_images_q4.onnx \
-        --decoder decoder_q4.onnx
+        --embed-images vision_encoder_q4.onnx \
+        --decoder decoder_model_merged_q4.onnx
 """
 
 import argparse
@@ -93,8 +93,8 @@ class VLModelInference:
 
         # Resolve file paths (use provided or default)
         embed_tokens_path = onnx_dir / (self.embed_tokens_file or "embed_tokens.onnx")
-        embed_images_path = onnx_dir / (self.embed_images_file or "embed_images.onnx")
-        decoder_path = onnx_dir / (self.decoder_file or "decoder.onnx")
+        embed_images_path = onnx_dir / (self.embed_images_file or "vision_encoder.onnx")
+        decoder_path = onnx_dir / (self.decoder_file or "decoder_model_merged.onnx")
 
         logger.info(f"  embed_tokens: {embed_tokens_path.name}")
         logger.info(f"  embed_images: {embed_images_path.name}")
@@ -269,10 +269,18 @@ def resolve_precision_files(
 
     precision = precision.lower()
     if precision == "fp16":
-        return "embed_tokens_fp16.onnx", "embed_images_fp16.onnx", "decoder_fp16.onnx"
+        return (
+            "embed_tokens_fp16.onnx",
+            "vision_encoder_fp16.onnx",
+            "decoder_model_merged_fp16.onnx",
+        )
     elif precision in ("q4", "q8"):
         # embed_tokens has no quantized version, use fp32
-        return "embed_tokens.onnx", f"embed_images_{precision}.onnx", f"decoder_{precision}.onnx"
+        return (
+            "embed_tokens.onnx",
+            f"vision_encoder_{precision}.onnx",
+            f"decoder_model_merged_{precision}.onnx",
+        )
     else:
         raise ValueError(f"Invalid precision: {precision}. Use fp16, q4, or q8.")
 

--- a/src/liquidonnx/session.py
+++ b/src/liquidonnx/session.py
@@ -9,6 +9,13 @@ import onnxruntime as ort
 logger = logging.getLogger(__name__)
 
 
+# Mapping from legacy component names to Transformers.js v4 names
+_COMPONENT_ALIASES = {
+    "embed_images": "vision_encoder",
+    "decoder": "decoder_model_merged",
+}
+
+
 def get_onnx_file(
     onnx_dir: pathlib.Path, precision: str | None, name: str = "model"
 ) -> pathlib.Path:
@@ -17,11 +24,21 @@ def get_onnx_file(
     Args:
         onnx_dir: Directory containing ONNX files
         precision: None for fp32, "fp16", "q4", "q8"
-        name: Base name of the model file (default: "model")
+        name: Base name of the model file (default: "model").
+              Accepts legacy names (embed_images, decoder) and resolves
+              to new names (vision_encoder, decoder_model_merged) with
+              fallback to legacy if the new file doesn't exist.
 
     Returns:
         Path to the ONNX file (e.g., model.onnx, model_q4.onnx, decoder_fp16.onnx)
     """
+    new_name = _COMPONENT_ALIASES.get(name)
+    if new_name:
+        suffix = f"_{precision}.onnx" if precision else ".onnx"
+        new_path = onnx_dir / f"{new_name}{suffix}"
+        if new_path.exists():
+            return new_path
+        # Fall back to legacy name
     if precision:
         return onnx_dir / f"{name}_{precision}.onnx"
     return onnx_dir / f"{name}.onnx"
@@ -167,8 +184,10 @@ class ONNXTextModel:
             tokenizer_path = self.model_path.parent.parent
         else:
             tokenizer_path = self.model_path
-            # Try decoder.onnx first (LFM2), then model.onnx
-            onnx_path = self.model_path / "onnx" / "decoder.onnx"
+            # Try decoder_model_merged.onnx first, then decoder.onnx (legacy), then model.onnx
+            onnx_path = self.model_path / "onnx" / "decoder_model_merged.onnx"
+            if not onnx_path.exists():
+                onnx_path = self.model_path / "onnx" / "decoder.onnx"
             if not onnx_path.exists():
                 onnx_path = self.model_path / "onnx" / "model.onnx"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -155,14 +155,14 @@ def get_local_vl_files(onnx_dir: pathlib.Path, use_fp16: bool = False) -> dict[s
 
     Local VL models use:
     - embed_tokens.onnx / embed_tokens_fp16.onnx
-    - embed_images.onnx / embed_images_fp16.onnx
-    - decoder.onnx / decoder_fp16.onnx
+    - vision_encoder.onnx / vision_encoder_fp16.onnx
+    - decoder_model_merged.onnx / decoder_model_merged_fp16.onnx
     """
     suffix = "_fp16" if use_fp16 else ""
     return {
         "embed_tokens": onnx_dir / f"embed_tokens{suffix}.onnx",
-        "embed_images": onnx_dir / f"embed_images{suffix}.onnx",
-        "decoder": onnx_dir / f"decoder{suffix}.onnx",
+        "vision_encoder": onnx_dir / f"vision_encoder{suffix}.onnx",
+        "decoder": onnx_dir / f"decoder_model_merged{suffix}.onnx",
     }
 
 

--- a/tests/test_lfm2_vl/test_edge_cases.py
+++ b/tests/test_lfm2_vl/test_edge_cases.py
@@ -131,9 +131,9 @@ def test_image_sizes(
     if not onnx_dir.exists():
         pytest.skip(f"Export not found: {onnx_dir}")
 
-    embed_images_file = onnx_dir / "embed_images.onnx"
+    embed_images_file = onnx_dir / "vision_encoder.onnx"
     if not embed_images_file.exists():
-        pytest.skip(f"embed_images not found: {embed_images_file}")
+        pytest.skip(f"vision_encoder not found: {embed_images_file}")
 
     embed_images_sess = load_onnx_session(embed_images_file)
 
@@ -177,9 +177,9 @@ def test_aspect_ratios(
     if not onnx_dir.exists():
         pytest.skip(f"Export not found: {onnx_dir}")
 
-    embed_images_file = onnx_dir / "embed_images.onnx"
+    embed_images_file = onnx_dir / "vision_encoder.onnx"
     if not embed_images_file.exists():
-        pytest.skip(f"embed_images not found: {embed_images_file}")
+        pytest.skip(f"vision_encoder not found: {embed_images_file}")
 
     embed_images_sess = load_onnx_session(embed_images_file)
 
@@ -216,9 +216,9 @@ def test_batch_different_sizes(
     if not onnx_dir.exists():
         pytest.skip(f"Export not found: {onnx_dir}")
 
-    embed_images_file = onnx_dir / "embed_images.onnx"
+    embed_images_file = onnx_dir / "vision_encoder.onnx"
     if not embed_images_file.exists():
-        pytest.skip(f"embed_images not found: {embed_images_file}")
+        pytest.skip(f"vision_encoder not found: {embed_images_file}")
 
     embed_images_sess = load_onnx_session(embed_images_file)
 
@@ -258,13 +258,13 @@ def test_full_inference_different_sizes(
         pytest.skip(f"Export not found: {onnx_dir}")
 
     embed_tokens_file = onnx_dir / "embed_tokens.onnx"
-    embed_images_file = onnx_dir / "embed_images.onnx"
-    decoder_file = onnx_dir / "decoder.onnx"
+    embed_images_file = onnx_dir / "vision_encoder.onnx"
+    decoder_file = onnx_dir / "decoder_model_merged.onnx"
 
     if not embed_tokens_file.exists():
         pytest.skip(f"embed_tokens not found: {embed_tokens_file}")
     if not embed_images_file.exists():
-        pytest.skip(f"embed_images not found: {embed_images_file}")
+        pytest.skip(f"vision_encoder not found: {embed_images_file}")
     if not decoder_file.exists():
         pytest.skip(f"decoder not found: {decoder_file}")
 


### PR DESCRIPTION
# Renames VL export outputs to match Transformers.js v4 session registry                                                                                        
                                                                                                                                                               
Transformers.js v4 hardcodes session-to-filename mappings for ImageTextToText models in session_config.js. It expects vision_encoder, embed_tokens, and decoder_model_merged as the ONNX file basenames.                                                                                                                                                 
                                                                                                                                                               
Changes:
- Rename embed_images → vision_encoder and decoder → decoder_model_merged across export, inference, quantization, and tests
- Generate preprocessor_config.json — Transformers.js reads this (flat format), not processor_config.json (nested under image_processor)
- Inline chat_template.jinja into tokenizer_config.json — Transformers.js reads it from there, not from the separate .jinja file. Strips {%- generation -%} / {%- endgeneration -%} blocks which the Transformers.js Jinja parser doesn't support
- Add transformers.js_config.use_external_data_format to config.json — tells Transformers.js which sessions have .onnx_data files to download                


get_onnx_file() in session.py falls back to the old names if the new ones aren't found, so existing exports still work. 