### PR TITLE
Allow parallel manual dispatches of the Test Export workflow

### DIFF
--- a/.github/workflows/test_export.yml
+++ b/.github/workflows/test_export.yml
@@ -54,9 +54,13 @@ on:
   pull_request:
     paths: *export-paths
 
+# Manual dispatches each get a unique group (the run id), so parameter sweeps —
+# e.g. one run per model/precision — execute in parallel instead of cancelling
+# each other. Push/PR runs keep one group per ref with cancel-in-progress, so a
+# superseded commit's run is still cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
   export:


### PR DESCRIPTION
## Problem

The Test Export workflow's concurrency group is keyed on `workflow + ref` with `cancel-in-progress: true`, so every manual dispatch on `main` lands in the same group — starting a second run (e.g. a different model/family/precision) cancels the one already in progress. That blocks parameter sweeps, like exercising each MoE precision in its own run.

## Fix

Key the group on `run_id` for `workflow_dispatch` events, so each manual run is its own group and they execute in parallel. Push/PR runs keep the existing behavior — one group per ref with `cancel-in-progress` — so a superseded commit's run is still cancelled.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
```

## Test plan

- `actionlint` passes (the one remaining SC2086 info is pre-existing and intentional — `$PRECISION` is deliberately unquoted to split multiple precisions).
- After merge: dispatch two runs back-to-back with different inputs — both should run to completion; a push to main while a push-triggered run is in flight should still cancel the older run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
