### PR TITLE
Expose VLModelInference as a servable public API (force_cpu, raw-text decode)

### DIFF
--- a/src/liquidonnx/lfm2_vl/__init__.py
+++ b/src/liquidonnx/lfm2_vl/__init__.py
@@ -2,3 +2,18 @@
 
 VISION_MODE_TILED = "tiled"
 VISION_MODE_CONV2D = "conv2d"
+
+# Public inference API. Imported after the constants above: infer.py (and the
+# modules it pulls in) import the constants back from this package, which works
+# only because they are already bound when the submodule import starts.
+from liquidonnx.lfm2_vl.infer import (  # noqa: E402
+    VLModelInference,
+    resolve_precision_files,
+)
+
+__all__ = [
+    "VISION_MODE_CONV2D",
+    "VISION_MODE_TILED",
+    "VLModelInference",
+    "resolve_precision_files",
+]

--- a/src/liquidonnx/lfm2_vl/infer.py
+++ b/src/liquidonnx/lfm2_vl/infer.py
@@ -45,7 +45,13 @@ def get_onnx_dir(exports_dir: Path, size: str) -> Path:
 
 
 class VLModelInference:
-    """ONNX inference for LFM2-VL models."""
+    """ONNX inference for LFM2-VL models.
+
+    Public API (re-exported from `liquidonnx.lfm2_vl`): embedding servers and
+    smoke harnesses load a repo directory and drive `generate` directly — the
+    CLI below is one such consumer. `generate` also handles text-only
+    conversations (no vision encoder run), so a VL export can serve plain chat.
+    """
 
     def __init__(
         self,
@@ -53,11 +59,13 @@ class VLModelInference:
         embed_tokens_file: str | None = None,
         embed_images_file: str | None = None,
         decoder_file: str | None = None,
+        force_cpu: bool = False,
     ):
         self.model_path = Path(model_path)
         self.embed_tokens_file = embed_tokens_file
         self.embed_images_file = embed_images_file
         self.decoder_file = decoder_file
+        self.force_cpu = force_cpu
         self.processor = None
         self.tokenizer = None
         self.embed_tokens_sess = None
@@ -100,9 +108,10 @@ class VLModelInference:
         logger.info(f"  embed_images: {embed_images_path.name}")
         logger.info(f"  decoder: {decoder_path.name}")
 
-        self.embed_tokens_sess = load_onnx_session(embed_tokens_path)
-        self.embed_images_sess = load_onnx_session(embed_images_path)
-        self.decoder_sess = load_onnx_session(decoder_path)
+        providers = ["CPUExecutionProvider"] if self.force_cpu else None
+        self.embed_tokens_sess = load_onnx_session(embed_tokens_path, providers=providers)
+        self.embed_images_sess = load_onnx_session(embed_images_path, providers=providers)
+        self.decoder_sess = load_onnx_session(decoder_path, providers=providers)
 
         self.vision_format = detect_vision_format(self.embed_images_sess)
         logger.info(f"Vision format: {self.vision_format}")
@@ -159,8 +168,14 @@ class VLModelInference:
         images: list[Image.Image] | None = None,
         max_new_tokens: int = 100,
         stream: bool = True,
+        skip_special_tokens: bool = True,
     ) -> str:
-        """Generate response for chat messages with optional images."""
+        """Generate response for chat messages with optional images.
+
+        `skip_special_tokens=False` keeps in-band markers (tool-call
+        delimiters, reasoning boundaries) in the returned text — serving
+        consumers parse them; the interactive CLI wants them stripped.
+        """
         images = images or []
 
         if images:
@@ -250,7 +265,7 @@ class VLModelInference:
         if stream:
             print()
 
-        return self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
+        return self.tokenizer.decode(generated_tokens, skip_special_tokens=skip_special_tokens)
 
 
 def resolve_precision_files(

--- a/src/liquidonnx/session.py
+++ b/src/liquidonnx/session.py
@@ -208,8 +208,14 @@ class ONNXTextModel:
         messages: list,
         max_new_tokens: int = 100,
         stream: bool = True,
+        skip_special_tokens: bool = True,
     ) -> str:
-        """Generate response for chat messages."""
+        """Generate response for chat messages.
+
+        `skip_special_tokens=False` keeps in-band markers (tool-call
+        delimiters, reasoning boundaries) in the returned text — serving
+        consumers parse them; the interactive CLI wants them stripped.
+        """
         prompt = self.tokenizer.apply_chat_template(
             messages, tokenize=False, add_generation_prompt=True
         )
@@ -260,7 +266,7 @@ class ONNXTextModel:
         if stream:
             print()
 
-        return self.tokenizer.decode(generated_tokens, skip_special_tokens=True)
+        return self.tokenizer.decode(generated_tokens, skip_special_tokens=skip_special_tokens)
 
 
 def run_chat_loop(model: ONNXTextModel, args) -> None:

--- a/tests/test_lfm2_vl/test_infer_api.py
+++ b/tests/test_lfm2_vl/test_infer_api.py
@@ -1,0 +1,107 @@
+"""Unit tests for the VLModelInference public API (no models, no downloads).
+
+Serving consumers (e.g. model-pipeline's ONNX smoke server) import
+`VLModelInference` from `liquidonnx.lfm2_vl` and rely on `force_cpu` and
+`skip_special_tokens` behaving like `ONNXTextModel`'s.
+
+Run: uv run pytest tests/test_lfm2_vl/test_infer_api.py -v
+"""
+
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from liquidonnx.lfm2_vl import VISION_MODE_TILED, VLModelInference, resolve_precision_files
+from liquidonnx.lfm2_vl import infer as infer_module
+
+
+def test_public_api_reexports_the_infer_module():
+    assert VLModelInference is infer_module.VLModelInference
+    assert resolve_precision_files is infer_module.resolve_precision_files
+
+
+class TestForceCpu:
+    def _load(self, tmp_path, monkeypatch, force_cpu: bool) -> list[list[str] | None]:
+        """Run load() with stubbed processor/sessions; return the providers
+        each of the three load_onnx_session calls received."""
+        (tmp_path / "tokenizer.json").write_text("{}")
+
+        tokenizer = Mock()
+        tokenizer.convert_tokens_to_ids.return_value = 396
+        processor = Mock()
+        processor.tokenizer = tokenizer
+        monkeypatch.setattr(
+            infer_module.AutoProcessor, "from_pretrained", Mock(return_value=processor)
+        )
+
+        seen_providers = []
+
+        def fake_load_onnx_session(path, providers=None):
+            seen_providers.append(providers)
+            return Mock()
+
+        monkeypatch.setattr(infer_module, "load_onnx_session", fake_load_onnx_session)
+        monkeypatch.setattr(
+            infer_module, "detect_vision_format", Mock(return_value=VISION_MODE_TILED)
+        )
+
+        model = VLModelInference(str(tmp_path), force_cpu=force_cpu)
+        model.load()
+        return seen_providers
+
+    def test_force_cpu_pins_every_session_to_cpu(self, tmp_path, monkeypatch):
+        providers = self._load(tmp_path, monkeypatch, force_cpu=True)
+        assert providers == [["CPUExecutionProvider"]] * 3
+
+    def test_default_auto_detects_providers(self, tmp_path, monkeypatch):
+        providers = self._load(tmp_path, monkeypatch, force_cpu=False)
+        assert providers == [None] * 3
+
+
+class TestGenerateSkipSpecialTokens:
+    EOS = 5
+
+    def _model(self) -> tuple[VLModelInference, Mock]:
+        """A text-only model with stubbed tokenizer and sessions: the decoder
+        emits EOS immediately, so generate() decodes a one-token response."""
+        model = VLModelInference("unused")
+
+        tokenizer = Mock()
+        tokenizer.apply_chat_template.return_value = "prompt"
+        tokenizer.encode.return_value = [1, 2]
+        tokenizer.eos_token_id = self.EOS
+        tokenizer.decode.return_value = "response"
+        model.tokenizer = tokenizer
+
+        embed_tokens = Mock()
+        # [1, seq_len, hidden] for the prompt, then [1, 1, hidden] per step.
+        embed_tokens.run.side_effect = lambda _out, feed: [
+            np.zeros((1, feed["input_ids"].shape[1], 4), dtype=np.float32)
+        ]
+        model.embed_tokens_sess = embed_tokens
+
+        decoder = Mock()
+        decoder.get_inputs.return_value = []  # no KV cache inputs, no position_ids
+        decoder.get_outputs.return_value = []
+        logits = np.zeros((1, 2, self.EOS + 1), dtype=np.float32)
+        logits[0, -1, self.EOS] = 1.0  # argmax -> EOS: stop after one token
+        decoder.run.return_value = [logits]
+        model.decoder_sess = decoder
+        return model, tokenizer
+
+    @pytest.mark.parametrize("skip", [True, False])
+    def test_final_decode_honors_the_flag(self, skip):
+        model, tokenizer = self._model()
+        out = model.generate(
+            [{"role": "user", "content": "hi"}],
+            stream=False,
+            skip_special_tokens=skip,
+        )
+        assert out == "response"
+        tokenizer.decode.assert_called_with([self.EOS], skip_special_tokens=skip)
+
+    def test_default_strips_special_tokens(self):
+        model, tokenizer = self._model()
+        model.generate([{"role": "user", "content": "hi"}], stream=False)
+        tokenizer.decode.assert_called_with([self.EOS], skip_special_tokens=True)


### PR DESCRIPTION
Blesses `VLModelInference` as a public, servable API so downstream consumers can serve VL exports — the immediate one being model-pipeline's ONNX inference smoke (Liquid4All/model-pipeline TEC-568 / PR #80), whose Python smoke server currently wraps `ONNXTextModel` and therefore skips VL exports entirely.

Changes, all backward-compatible:

- **Re-export `VLModelInference` and `resolve_precision_files` from `liquidonnx.lfm2_vl`** — the class already did everything a server needs (including the text-only generate path); it just lived inside the CLI module with no public blessing.
- **`VLModelInference(force_cpu=...)`** — parity with `ONNXTextModel`; pins all three sessions to the CPU EP for CPU-only serving containers.
- **`generate(..., skip_special_tokens=...)` on both `VLModelInference` and `ONNXTextModel`** (default `True`, unchanged) — serving consumers want the in-band markers (tool-call delimiters, reasoning boundaries) preserved for parsing; the interactive CLIs keep stripping them.

Tests: `tests/test_lfm2_vl/test_infer_api.py` — lightweight Mock-based unit tests (no model downloads), covering the public re-export, the provider pinning of all three sessions, and the decode flag on the text-only generate path.

```
uv run pytest tests/test_lfm2_vl/test_infer_api.py -v   # 6 passed
uv run ruff check src tests                              # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
