### PR TITLE
Make remote model code execution explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ uv sync --extra gpu
 uv sync --extra dev
 ```
 
+Model loading does not execute Python code from Hugging Face repositories by default. For a
+trusted repository that requires custom Transformers code, explicitly opt in:
+
+```bash
+$env:LIQUIDONNX_TRUST_REMOTE_CODE = "1"  # PowerShell
+uv run lfm2-infer --model ./exports/LFM2.5-1.2B-Instruct-ONNX/onnx/model_q4.onnx
+```
+
 ## 3. Export
 
 ### 3.1 LFM2 Text Models

--- a/src/liquidonnx/__init__.py
+++ b/src/liquidonnx/__init__.py
@@ -2,4 +2,15 @@
 LiquidONNX - ONNX export and inference tools for LFM2 models.
 """
 
+import os
+
 __version__ = "0.1.0"
+
+
+def remote_code_enabled() -> bool:
+	"""Return whether loading Python code from model repositories is allowed."""
+	return os.environ.get("LIQUIDONNX_TRUST_REMOTE_CODE", "").lower() in {
+		"1",
+		"true",
+		"yes",
+	}

--- a/src/liquidonnx/lfm2/benchmark.py
+++ b/src/liquidonnx/lfm2/benchmark.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from liquidonnx import remote_code_enabled
 from liquidonnx.quantize import get_total_model_size_mb
 from liquidonnx.session import initialize_cache, load_onnx_session, update_cache
 
@@ -48,7 +49,9 @@ class ONNXBenchmark:
         from transformers import AutoTokenizer
 
         logger.info(f"Loading tokenizer: {self.model_path}")
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_path, trust_remote_code=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_path, trust_remote_code=remote_code_enabled()
+        )
 
     def load_onnx_model(self, onnx_path: str):
         """Load ONNX model and return session + load time."""

--- a/src/liquidonnx/lfm2/export.py
+++ b/src/liquidonnx/lfm2/export.py
@@ -48,6 +48,7 @@ import pathlib
 import onnx
 from transformers import AutoConfig, AutoTokenizer
 
+from liquidonnx import remote_code_enabled
 from liquidonnx.external_data import split_external_data
 from liquidonnx.lfm2.builder import LFM2Builder, LFM2Config
 from liquidonnx.quantize import get_model_size, get_total_model_size_mb, quantize_model
@@ -126,7 +127,7 @@ def export_model(model_path: str, output_dir: pathlib.Path | str):
             └── model.onnx_data
     """
     output_dir = pathlib.Path(output_dir)
-    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=remote_code_enabled())
     lfm2_config = LFM2Config.from_hf_config(config)
 
     builder = LFM2Builder(lfm2_config)
@@ -152,7 +153,7 @@ def export_model(model_path: str, output_dir: pathlib.Path | str):
 
     logger.info(f"Model saved to {output_path}")
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=remote_code_enabled())
     tokenizer.save_pretrained(output_dir)
     config.save_pretrained(output_dir)
 

--- a/src/liquidonnx/lfm2_audio/infer.py
+++ b/src/liquidonnx/lfm2_audio/infer.py
@@ -51,6 +51,8 @@ import time
 import numpy as np
 import onnxruntime as ort
 
+from liquidonnx import remote_code_enabled
+
 logger = logging.getLogger(__name__)
 
 # === Default System Prompts ===
@@ -209,7 +211,9 @@ class LFM2AudioInference:
         # Load tokenizer
         from transformers import AutoTokenizer
 
-        self.tokenizer = AutoTokenizer.from_pretrained(str(model_dir), trust_remote_code=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            str(model_dir), trust_remote_code=remote_code_enabled()
+        )
 
         # Resolve file paths (use provided or default)
         decoder_path = self.onnx_dir / (decoder_file or "decoder.onnx")

--- a/src/liquidonnx/lfm2_moe/export.py
+++ b/src/liquidonnx/lfm2_moe/export.py
@@ -42,6 +42,7 @@ import pathlib
 import onnx
 from transformers import AutoConfig, AutoTokenizer
 
+from liquidonnx import remote_code_enabled
 from liquidonnx.external_data import split_external_data
 from liquidonnx.lfm2_moe.builder import LFM2MoEBuilder, LFM2MoEConfig
 from liquidonnx.quantize import get_total_model_size_mb, quantize_model
@@ -334,7 +335,7 @@ def export_model(
         use_q4: Full Q4 quantization matching onnx-community Q4 structure
     """
     output_dir = pathlib.Path(output_dir)
-    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=remote_code_enabled())
     lfm2_config = LFM2MoEConfig.from_hf_config(config)
 
     # Always use integrated RoPE to match community structure
@@ -372,7 +373,7 @@ def export_model(
 
     logger.info(f"Model saved to {output_path}")
 
-    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=remote_code_enabled())
     tokenizer.save_pretrained(output_dir)
     config.save_pretrained(output_dir)
 

--- a/src/liquidonnx/lfm2_vl/benchmark.py
+++ b/src/liquidonnx/lfm2_vl/benchmark.py
@@ -21,6 +21,7 @@ import onnxruntime as ort
 from PIL import Image
 from transformers import AutoProcessor
 
+from liquidonnx import remote_code_enabled
 from liquidonnx.lfm2_vl import VISION_MODE_CONV2D, VISION_MODE_TILED
 from liquidonnx.lfm2_vl.preprocessing import (
     build_inputs_embeds,
@@ -127,7 +128,9 @@ class VLBenchmark:
 
         hf_model = self._get_hf_model_name()
         logger.info(f"Loading processor from {hf_model}...")
-        self.processor = AutoProcessor.from_pretrained(hf_model, trust_remote_code=True)
+        self.processor = AutoProcessor.from_pretrained(
+            hf_model, trust_remote_code=remote_code_enabled()
+        )
         self.tokenizer = self.processor.tokenizer
         self.image_token_id = get_image_token_id(self.tokenizer)
 

--- a/src/liquidonnx/lfm2_vl/export.py
+++ b/src/liquidonnx/lfm2_vl/export.py
@@ -51,6 +51,7 @@ import re
 import onnx
 from onnx import TensorProto, helper
 
+from liquidonnx import remote_code_enabled
 from liquidonnx.external_data import split_external_data
 from liquidonnx.lfm2.builder import LFM2Builder
 from liquidonnx.lfm2_vl import VISION_MODE_CONV2D, VISION_MODE_TILED
@@ -178,7 +179,7 @@ def export_vl_model(
     # Load model weights
     logger.info(f"Loading weights from {model_path}...")
     model = AutoModelForImageTextToText.from_pretrained(
-        model_path, torch_dtype=torch.float32, trust_remote_code=True
+         model_path, torch_dtype=torch.float32, trust_remote_code=remote_code_enabled()
     )
 
     weights = {}
@@ -379,11 +380,15 @@ def export_vl_model(
 
     # Copy tokenizer and config
     try:
-        processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+        processor = AutoProcessor.from_pretrained(
+            model_path, trust_remote_code=remote_code_enabled()
+        )
         processor.save_pretrained(output_dir)
     except Exception as e:
         logger.warning(f"Could not save processor: {e}")
-        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=remote_code_enabled()
+        )
         tokenizer.save_pretrained(output_dir)
 
     config.save_pretrained(output_dir)

--- a/src/liquidonnx/lfm2_vl/infer.py
+++ b/src/liquidonnx/lfm2_vl/infer.py
@@ -26,6 +26,7 @@ import numpy as np
 from PIL import Image
 from transformers import AutoProcessor
 
+from liquidonnx import remote_code_enabled
 from liquidonnx.lfm2_vl import VISION_MODE_CONV2D, VISION_MODE_TILED
 from liquidonnx.lfm2_vl.preprocessing import (
     build_inputs_embeds,
@@ -85,7 +86,9 @@ class VLModelInference:
                 hf_model = str(self.model_path)
 
         logger.info(f"Loading processor from {hf_model}...")
-        self.processor = AutoProcessor.from_pretrained(hf_model, trust_remote_code=True)
+        self.processor = AutoProcessor.from_pretrained(
+            hf_model, trust_remote_code=remote_code_enabled()
+        )
         self.tokenizer = self.processor.tokenizer
         self.image_token_id = self.tokenizer.convert_tokens_to_ids("<image>")
 

--- a/src/liquidonnx/session.py
+++ b/src/liquidonnx/session.py
@@ -6,6 +6,8 @@ import pathlib
 import numpy as np
 import onnxruntime as ort
 
+from liquidonnx import remote_code_enabled
+
 logger = logging.getLogger(__name__)
 
 
@@ -194,7 +196,9 @@ class ONNXTextModel:
         if not onnx_path.exists():
             raise FileNotFoundError(f"ONNX file not found: {onnx_path}")
 
-        self.tokenizer = AutoTokenizer.from_pretrained(str(tokenizer_path), trust_remote_code=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            str(tokenizer_path), trust_remote_code=remote_code_enabled()
+        )
 
         providers = ["CPUExecutionProvider"] if self.force_cpu else None
         logger.info(f"Loading ONNX from {onnx_path}...")


### PR DESCRIPTION
## Summary

Make execution of Python code from Hugging Face model repositories an explicit opt-in instead of enabling it implicitly during model loading.

## Security impact

`trust_remote_code=True` allows custom Python shipped by a model repository to execute while Transformers loads a model, tokenizer, or processor. This is necessary for some custom model implementations, but it should be a deliberate trust decision rather than the default behavior.

## Changes

- Add `LIQUIDONNX_TRUST_REMOTE_CODE` as the opt-in control.
- Keep remote code disabled unless the variable is set to `1`, `true`, or `yes`.
- Apply the policy consistently to text, MoE, VL, and audio exporters, inference paths, and benchmarks.
- Document the trusted-repository opt-in in the README.

Example:

```bash
$env:LIQUIDONNX_TRUST_REMOTE_CODE = "1"  # PowerShell
uv run lfm2-infer --model ./exports/LFM2.5-1.2B-Instruct-ONNX/onnx/model_q4.onnx
```

## Compatibility

Repositories that only provide standard Transformers configurations continue to work without custom code. Repositories that require custom Python code must now opt in explicitly.

## Validation

- `python -m compileall -q src` passes.
- No unconditional `trust_remote_code=True` remains in `src`.
- `git diff --check` passes.
- Ruff could not run locally because installing PyTorch exhausted available disk space; CI will run the configured format and lint checks.