### PR TITLE
Pin CI actions and Git dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -14,9 +14,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
       - run: uv python install 3.12
       - run: uv sync --extra dev
       - run: uv run ruff format --check src tests

--- a/.github/workflows/test_export.yml
+++ b/.github/workflows/test_export.yml
@@ -70,7 +70,7 @@ jobs:
     outputs:
       inference_passed: ${{ steps.infer.outputs.inference_passed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # ONNX exports (fp32 base + quantized copies) are large; reclaim the disk
       # the GitHub image spends on toolchains this job doesn't use.
@@ -80,7 +80,7 @@ jobs:
             /opt/hostedtoolcache/CodeQL /usr/local/share/boost
           df -h /
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - run: uv python install 3.12
       - run: uv sync
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ url = "https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Night
 explicit = true
 
 [tool.uv.sources]
-transformers = { git = "https://github.com/huggingface/transformers.git", rev = "3c25177" }
+transformers = { git = "https://github.com/huggingface/transformers.git", rev = "3c2517727ce28a30f5044e01663ee204deb1cdbe" }
 onnxruntime = { index = "ort-nightly" }
 onnxruntime-gpu = { index = "ort-nightly" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.12.0" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "torchvision", specifier = ">=0.24.1" },
-    { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=3c25177" },
+    { name = "transformers", git = "https://github.com/huggingface/transformers.git?rev=3c2517727ce28a30f5044e01663ee204deb1cdbe" },
 ]
 provides-extras = ["gpu", "dev"]
 
@@ -1891,7 +1891,7 @@ wheels = [
 [[package]]
 name = "transformers"
 version = "5.0.0.dev0"
-source = { git = "https://github.com/huggingface/transformers.git?rev=3c25177#3c2517727ce28a30f5044e01663ee204deb1cdbe" }
+source = { git = "https://github.com/huggingface/transformers.git?rev=3c2517727ce28a30f5044e01663ee204deb1cdbe#3c2517727ce28a30f5044e01663ee204deb1cdbe" }
 dependencies = [
     { name = "filelock" },
     { name = "huggingface-hub" },


### PR DESCRIPTION
## Summary

Pin CI actions and the Transformers Git dependency to immutable revisions, and configure Dependabot to maintain both dependency sources on a controlled cadence.

## Changes

- Pin `actions/checkout` in both workflows to full commit SHAs.
- Pin `astral-sh/setup-uv` in both workflows to full commit SHAs.
- Replace the short Transformers revision in `pyproject.toml` with the full commit SHA already resolved by the lockfile.
- Update `uv.lock` to preserve the same Transformers commit while recording the immutable revision.
- Add Dependabot configuration for `uv` and GitHub Actions updates.
- Schedule Dependabot checks monthly with a seven-day cooldown before updates are proposed.

## Security impact

This improves supply-chain traceability for CI and dependency resolution. Reviewers can verify exactly which action commits and Transformers source revision are used by the project, while the Dependabot cooldown gives new releases time to surface issues before automated update PRs are opened.

## Scope

- No application code or runtime behavior changes.
- No author or affiliation context included.
- The ONNX Runtime nightly index remains unchanged because it is required for the current QMoE support.

## Validation

- `python -m compileall -q src` passes.
- `git diff --check` passes.
- Ruff could not run locally because installing PyTorch exhausted available disk space; CI will run the configured format and lint checks.